### PR TITLE
bugfix/nested extraneous package removal

### DIFF
--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -361,7 +361,6 @@ export default class PackageLinker {
       }
     };
 
-
     await findExtraneousFiles(this.config.lockfileFolder);
     if (workspaceLayout) {
       for (const workspaceName of Object.keys(workspaceLayout.workspaces)) {

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -345,18 +345,22 @@ export default class PackageLinker {
 
               for (const subfile of await fs.readdir(filepath)) {
                 possibleExtraneous.add(path.join(filepath, subfile));
+                await findExtraneousFiles(path.join(filepath, subfile));
               }
             } else if (file[0] === '.' && file !== '.bin') {
               if (!(await fs.lstat(filepath)).isDirectory()) {
                 possibleExtraneous.add(filepath);
+                await findExtraneousFiles(filepath);
               }
             } else {
               possibleExtraneous.add(filepath);
+              await findExtraneousFiles(filepath);
             }
           }
         }
       }
     };
+
 
     await findExtraneousFiles(this.config.lockfileFolder);
     if (workspaceLayout) {

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -476,16 +476,25 @@ export default class PackageLinker {
     });
 
     // remove all extraneous files that weren't in the tree
-    for (const loc of possibleExtraneous) {
+    for (const loc of possibleExtraneous) {      
       this.reporter.verbose(this.reporter.lang('verboseFileRemoveExtraneous', loc));
-      await fs.unlink(loc);
+      try {
+        await fs.unlink(loc);
+      } catch (err) {
+        this.reporter.verbose(`Could not unlink ${loc}: ${err.message}`);
+      }
+
     }
 
     // remove any empty scoped directories
     for (const scopedPath of scopedPaths) {
-      const files = await fs.readdir(scopedPath);
-      if (files.length === 0) {
-        await fs.unlink(scopedPath);
+      try {
+        const files = await fs.readdir(scopedPath);
+        if (files.length === 0) {
+          await fs.unlink(scopedPath);
+        }
+      } catch (err) {
+        this.reporter.verbose(`Could not remove scoped dir ${scopedPath}: ${err.message}`);
       }
     }
 


### PR DESCRIPTION
This change ensures nested dependencies are considered for removal.

yarn would only scan the top level packages to generate a list of
candidate packages for removal. When modifying the package tree in
such a way that a nested dependency is no longer required, yarn would
not remove this nested package which could cause subsequent problems
with resolution. The fix was to remove `node_modules` and install
again.

This change will now recursively call `findExtraneousFiles` in
`package-linker`, which means that nested dependencies that are no
longer present in the desired tree are now correctly removed.