### PR TITLE
Fix inclusion of prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn",
   "installationMethod": "unknown",
-  "version": "1.23.0-atlassian.2",
+  "version": "1.23.0-atlassian.3",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "request": "^2.87.0",
     "request-capture-har": "^1.2.2",
     "rimraf": "^2.5.0",
-    "semver": "atlassian-forks/node-semver.git#refs/heads/alwasIncludePrerelease",
+    "semver": "^7.3.2",
     "ssri": "^5.3.0",
     "strip-ansi": "^4.0.0",
     "strip-bom": "^3.0.0",

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -59,22 +59,17 @@ type Versions = {
   [engineName: string]: ?string,
 };
 
-/*
- Atlassian patched this function:
- - IncludePrerelease in compatility check, this should make deduplication work properly when using branch deploys
-*/
-
 export function testEngine(name: string, range: string, versions: Versions, looseSemver: boolean): boolean {
   const actual = versions[name];
   if (!actual) {
     return false;
   }
 
-  if (!semver.valid(actual, {loose: looseSemver, includePrerelease: true })) {
+  if (!semver.valid(actual, looseSemver)) {
     return false;
   }
 
-  if (semver.satisfies(actual, range, {loose: looseSemver, includePrerelease: true })) {
+  if (semver.satisfies(actual, range, looseSemver)) {
     return true;
   }
 

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -59,21 +59,22 @@ type Versions = {
   [engineName: string]: ?string,
 };
 
+/*
+ Atlassian patched this function:
+ - IncludePrerelease in compatility check, this should make deduplication work properly when using branch deploys
+*/
+
 export function testEngine(name: string, range: string, versions: Versions, looseSemver: boolean): boolean {
   const actual = versions[name];
   if (!actual) {
     return false;
   }
 
-  if (!semver.valid(actual, looseSemver)) {
+  if (!semver.valid(actual, {loose: looseSemver, includePrerelease: true })) {
     return false;
   }
 
-  if (semver.satisfies(actual, range, looseSemver)) {
-    return true;
-  }
-
-  if (name === 'yarn' && satisfiesWithPrereleases(actual, range, looseSemver)) {
+  if (semver.satisfies(actual, range, {loose: looseSemver, includePrerelease: true })) {
     return true;
   }
 

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -78,6 +78,10 @@ export function testEngine(name: string, range: string, versions: Versions, loos
     return true;
   }
 
+  if (name === 'yarn' && satisfiesWithPrereleases(actual, range, looseSemver)) {
+    return true;
+  }
+
   if (name === 'node' && semver.gt(actual, '1.0.0', looseSemver)) {
     // WARNING: this is a massive hack and is super gross but necessary for compatibility
     // some modules have the `engines.node` field set to a caret version below semver major v1

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -476,11 +476,11 @@ export default class PackageResolver {
    */
   isLockfileEntryOutdated(version: string, range: string, hasVersion: boolean): boolean {
     return !!(
-      semver.validRange(range) &&
-      semver.valid(version) &&
-      !getExoticResolver(range) &&
+      semver.validRange(range, {includePrerelease: true}) &&
+      semver.valid(version, {includePrerelease: true}) &&
+      !getExoticResolver(range, {includePrerelease: true}) &&
       hasVersion &&
-      !semver.satisfies(version, range)
+      !semver.satisfies(version, range, {includePrerelease: true})
     );
   }
 

--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -473,6 +473,10 @@ export default class PackageResolver {
 
   /**
    * Determine if LockfileEntry is incorrect, remove it from lockfile cache and consider the pattern as new
+   *
+   * Atlassian-fork: Include prereleases to allow the following lock entries:
+   * "@atlaskit/avatar-group@8.4.0-alpha-0371f4c06e53", "@atlaskit/avatar-group@^8.0.0", "@atlaskit/avatar-group@^8.0.14", "@atlaskit/avatar-group@^8.2.0", "@atlaskit/avatar-group@^8.3.0
+   * This is the result of deduping on a branch that uses atlassian-frontend branch deploys
    */
   isLockfileEntryOutdated(version: string, range: string, hasVersion: boolean): boolean {
     return !!(

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -11,7 +11,7 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
   let semverRange;
   try {
     // $FlowFixMe: Add a definition for the Range class
-    semverRange = new semver.Range(range, loose);
+    semverRange = new semver.Range(range, {includePrerelease: true, loose});
   } catch (err) {
     return false;
   }
@@ -21,7 +21,7 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
   }
   let semverVersion;
   try {
-    semverVersion = new semver.SemVer(version, semverRange.loose);
+    semverVersion = new semver.SemVer(version, {includePrerelease: true, loose: semverRange.loose});
   } catch (err) {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5064,6 +5064,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 lru-queue@0.1:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
@@ -6673,9 +6680,12 @@ semver-greatest-satisfied-range@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
   integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
-semver@atlassian-forks/node-semver.git#refs/heads/alwasIncludePrerelease:
-  version "7.3.2"
-  resolved "https://codeload.github.com/atlassian-forks/node-semver/tar.gz/6a44178f1cd79bdea8e57638696a8962b859f17b"
+semver@^7.3.2:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -7835,6 +7845,11 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
My original implementation of the include prereleases fix
was too naive,as it just forced yarn to include prereleases everywhere.
Which resulted in yarn add also resolving to prereleases
yarn add package@^1.0.0
Would resolve to
package@1.0.1-alpha
if that existed. This is obviously undesirable, but we still want to dedupe
across alpha's, i.e:
"@atlaskit/avatar-group@8.4.0-alpha-0371f4c06e53", "@atlaskit/avatar-group@^8.0.0"
lock entries.