### PR TITLE
Clean up last PR

### DIFF
--- a/src/package-resolver.js
+++ b/src/package-resolver.js
@@ -482,7 +482,7 @@ export default class PackageResolver {
     return !!(
       semver.validRange(range, {includePrerelease: true}) &&
       semver.valid(version, {includePrerelease: true}) &&
-      !getExoticResolver(range, {includePrerelease: true}) &&
+      !getExoticResolver(range) &&
       hasVersion &&
       !semver.satisfies(version, range, {includePrerelease: true})
     );

--- a/src/util/semver.js
+++ b/src/util/semver.js
@@ -11,7 +11,7 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
   let semverRange;
   try {
     // $FlowFixMe: Add a definition for the Range class
-    semverRange = new semver.Range(range, {includePrerelease: true, loose});
+    semverRange = new semver.Range(range, loose);
   } catch (err) {
     return false;
   }
@@ -21,7 +21,7 @@ export function satisfiesWithPrereleases(version: string, range: string, loose?:
   }
   let semverVersion;
   try {
-    semverVersion = new semver.SemVer(version, {includePrerelease: true, loose: semverRange.loose});
+    semverVersion = new semver.SemVer(version, semverRange.loose);
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
Noticed some mistakes / unnecessary changes. 

`getExoticResolver` doesn't have a 2nd argument and also doesn't need to know about prereleases

src/util/semver.js `satisfiesWithPrereleases` already has it's own prerelease logic. We could clean up this logic by using semver's native includePrerelease (didn't exist with the original version of semver this yarn was shipped with), but I'd rather not mess with the internals of yarn too much.