### PR TITLE
Fix nested node modules of workspaces & linked packages being deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn",
   "installationMethod": "unknown",
-  "version": "1.23.0-atlassian.3",
+  "version": "1.23.0-atlassian.5",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/src/package-linker.js
+++ b/src/package-linker.js
@@ -431,6 +431,7 @@ export default class PackageLinker {
         }
 
         possibleExtraneous.add(fpath);
+
         /* Don't recurse into workspace symlinks for two reasons:
          *  1. Symlinked paths are renamed to their real paths before being added to the copy queue which
          *     prevents recursive modules in the copy queue matching with `possibleExtraneous`. This prevents


### PR DESCRIPTION
The recursive extraneous file removal was over-eager and deleting
workspace & linked package node_modules as well.

We noticed this happening in two scenarios:

1. When we accidentally allowed multiple versions of a dependency in the repo. The version nested in the workspace was being deleted.
2. When we only had one version of a direct dependency in the repo but also had a transitive version of said dependency. If we did _not_ specify the direct dependency in the root package.json as well, yarn installed the transitive version in the root which then caused the direct dependency to be installed in a workspace and then get deleted by the extraneous removal.

Presumably jira don't hit these use cases because they still require dependencies be declared in the root and support multiple dependency versions in a way where they are not nested inside workspaces.

I also noticed modules that had been `yarn link`d were also being deleted because I linked the forked version of `yarn` into our repo as part of testing this change.

There are two primary changes:

1. We check if a filepath is a workspace or not and only recurse if it is not.
2. We don't add linked modules to `possibleExtraneous` at all instead of removing them afterwards. This means we skip recursing into them completely and don't have to try to delete nested module filepaths of linked modules which would involve messing around with filepaths. To do this I moved the main `findExtraneousFiles` definition & call to below where `linkTargets` is populated so that we can re-use the existing check that removed the linked modules after the fact.

I've validated the change against the `fast-json-patch` use case that @cheesehary and I hit the other day. I'll perform some more testing tomorrow with an updated bundle in CI.