### PR TITLE
determine the right dependency type when running add and upgrade in workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarn",
   "installationMethod": "unknown",
-  "version": "1.23.0-atlassian.5",
+  "version": "1.23.0-atlassian.6",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -277,11 +277,11 @@ export class Add extends Install {
       if (cwdManifest) {
         // when running `yarn upgrade` or `yarn add` inside workspaces
         // we determine dependency type using the workspace package.json instead of root patterns
-        if (cwdManifest.dependencies[pkg.name]) {
-          target = 'dependencies'
+        if (cwdManifest.dependencies && cwdManifest.dependencies[pkg.name]) {
+          target = 'dependencies';
         }
-        else if (cwdManifest.devDependencies[pkg.name]) {
-          target = 'devDependencies'
+        else if (cwdManifest.devDependencies && cwdManifest.devDependencies[pkg.name]) {
+          target = 'devDependencies';
         }
         else {
           target = this.flagToOrigin;


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/issues/4664

When running `yarn add` or `yarn upgrade` in workspaces, yarn will determine the dependency type using the root `package.json`. This results in `yarn add foo` adding `foo` to the `devDependencies` in the workspace, if it's defined as a dev dep in the root.

This change will check the workspace `package.json` instead when running `yarn add` or `yarn upgrade` to decide the dependency type. If the dep exists in the workspace `package.json`, it'll keep the same dep type. If not, it'll respect the flag when running the command.